### PR TITLE
Fixes for NewMessage and GetMessages

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -98,9 +98,9 @@ namespace AE.Net.Mail {
 
     private void IdleResumeCommand() {
       var response = SendCommandGetResponse(GetTag() + "IDLE");
-      response = response.Substring(response.IndexOf(" ")).Trim();
-      if (!response.TrimStart().StartsWith("idling", StringComparison.OrdinalIgnoreCase))
-        throw new Exception(response);
+      //response = response.Substring(response.IndexOf(" ")).Trim();
+      //if (!response.TrimStart().StartsWith("idling", StringComparison.OrdinalIgnoreCase))
+      //    throw new Exception(response);
     }
 
     private bool HasEvents {


### PR DESCRIPTION
https://github.com/andyedinborough/aenetmail/issues/1
Removing one extra call to GetResponse which I'm assuming is a typo.

https://github.com/andyedinborough/aenetmail/issues/16
Checking that message count > 0 before raising NewMessage. This _seems_ like the correct thing to do, but I could be misreading the specs for IDLE.
