### PR TITLE
Fixed two NullReferenceExceptions

### DIFF
--- a/Pop3Client.cs
+++ b/Pop3Client.cs
@@ -15,7 +15,10 @@ namespace AE.Net.Mail {
         }
 
         internal override void OnLogout() {
-            SendCommand("QUIT");
+            if (_Stream != null)
+            {
+                SendCommand("QUIT");
+            }
         }
 
         internal override void CheckResultOK(string result) {

--- a/TextClient.cs
+++ b/TextClient.cs
@@ -122,7 +122,7 @@ namespace AE.Net.Mail {
         _Stream.Dispose();
         _Stream = null;
       }
-      if (!_ReadThread.Join(2000)) {
+      if (_ReadThread != null && !_ReadThread.Join(2000)) {
         _ReadThread.Abort();
       }
     }


### PR DESCRIPTION
That can occur if Dispose() is called and Connect() hasn't succeeded.

This typically happens when using the using() construct:

  using (var pop3 = new Pop3Client())
  {
    pop3.Connect(...);  # Fails for some reason

  } # Throws a NullReferenceException here
