### PR TITLE
Added the possibility to skip ssl certificate validation process if needed.

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -20,8 +20,9 @@ namespace AE.Net.Mail {
 
     private string _FetchHeaders = null;
 
-    public ImapClient(string host, string username, string password, AuthMethods method = AuthMethods.Login, int port = 143, bool secure = false) {
-      Connect(host, port, secure);
+    public ImapClient(string host, string username, string password, AuthMethods method = AuthMethods.Login, int port = 143, bool secure = false, bool skipSslValidation = false)
+    {
+        Connect(host, port, secure, skipSslValidation);
       AuthMethod = method;
       Login(username, password);
     }

--- a/Pop3Client.cs
+++ b/Pop3Client.cs
@@ -4,8 +4,9 @@ using System.Text;
 namespace AE.Net.Mail {
     public class Pop3Client : TextClient, IMailClient {
         public Pop3Client() { }
-        public Pop3Client(string host, string username, string password, int port = 110, bool secure = false) {
-            Connect(host, port, secure);
+        public Pop3Client(string host, string username, string password, int port = 110, bool secure = false, bool skipSslValidation = false)
+        {
+            Connect(host, port, secure, skipSslValidation);
             Login(username, password);
         }
 

--- a/TextClient.cs
+++ b/TextClient.cs
@@ -41,7 +41,8 @@ namespace AE.Net.Mail {
     }
 
 
-    public void Connect(string hostname, int port, bool ssl) {
+    public void Connect(string hostname, int port, bool ssl, bool skipSslValidation)
+    {
       try {
         Host = hostname;
         Port = port;
@@ -50,7 +51,11 @@ namespace AE.Net.Mail {
         _Connection = new TcpClient(hostname, port);
         _Stream = _Connection.GetStream();
         if (ssl) {
-          var sslStream = new System.Net.Security.SslStream(_Stream, false);
+            System.Net.Security.SslStream sslStream;
+            if (skipSslValidation)
+                sslStream = new System.Net.Security.SslStream(_Stream, false, (sender, cert, chain, err) => true);
+            else
+                sslStream = new System.Net.Security.SslStream(_Stream, false);
           _Stream = sslStream;
           sslStream.AuthenticateAsClient(hostname);
         }


### PR DESCRIPTION
Added a mandatory bool parameter skipSslValidation in TextClient Connect method, specifying if, when using ssl, the certificate validation step should be skipped.
Added a corresponding bool parameter in ImapClient and Pop3Client as an optional parameter so that previous codes won't change.
The default behavior is not to skip the certificate validation step. If the validation should be skipped, it has to be explicitly specified when creating the ImapClient or Pop3Client.

See issue #40 for details.
