### PR TITLE
Html body recognize enanchements 

### DIFF
--- a/MailMessage.cs
+++ b/MailMessage.cs
@@ -114,9 +114,9 @@ namespace AE.Net.Mail {
         } else {
           SetBody((line + Environment.NewLine + reader.ReadToEnd()).Trim());
         }
-
-       if (string.IsNullOrEmpty(Body) && string.IsNullOrEmpty(Body.Trim()) && Attachments != null && Attachments.Count > 0) {    var att = Attachments.FirstOrDefault(x => !x.IsAttachment && x.ContentType.Is("text/plain"));
-          if (att == null) {
+        
+      if ((Body == null || string.IsNullOrEmpty(Body.Trim())) && Attachments != null && Attachments.Count > 0) {
+        if (att == null) {
             att = Attachments.FirstOrDefault(x => !x.IsAttachment && x.ContentType.Contains("html"));
           }
 


### PR DESCRIPTION
-Added IsBodyHtml in implicit operator to System.Net.Mail.MailMessage
-Applied Trim() to body to avoid the wrong interpretation of not trimmed empty body

this is related to the #46 and #45. Sorry for the duplication, but i used github for the first time
