### PR TITLE
Update Utilities.cs

### DIFF
--- a/Utilities.cs
+++ b/Utilities.cs
@@ -69,7 +69,7 @@ namespace AE.Net.Mail {
     internal static DateTime? ToNullDate(this string input) {
       DateTime result;
       input = NormalizeDate(input);
-      if (DateTime.TryParse(input, out result)) {
+      if (DateTime.TryParse(input, CultureInfo.GetCultureInfo("en"), DateTimeStyles.None, out result)) {
         return result;
       } else {
         return null;


### PR DESCRIPTION
The problem is caused by the thread local culture, i think that the dotnet framework have a bug in the parse method for the datetime.. if the current culture is italian (or another latin language.. i suppose), it simply do not works for the may month.
i wrote this about the topic: http://stackoverflow.com/questions/9521016/datetime-parse-fails-for-today-01-mar-2012-o-0

My fix should work.
