### PR TITLE
Error compiling AENetMail as a project reference in another solution

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
-        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
+        <NuGetToolsPath>$(ProjectDir).nuget</NuGetToolsPath>
         <NuGetExePath>$(NuGetToolsPath)\nuget.exe</NuGetExePath>
         <PackagesConfig>$(ProjectDir)packages.config</PackagesConfig>
         <PackagesDir>$(ProjectDir)packages</PackagesDir>

--- a/AE.Net.Mail.csproj
+++ b/AE.Net.Mail.csproj
@@ -108,7 +108,7 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(ProjectDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
I'm trying to use aenetmail as a project reference by using submodules, but some references of nuget are causing the project to not to compile. Changing these references from SolutionDir to ProjectDir corrects this issue when compiling from another solution.
