### PR TITLE
Marking all public and protected methods and properties as virtual

### DIFF
--- a/Attachment.cs
+++ b/Attachment.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace AE.Net.Mail {
   public class Attachment : ObjectWHeaders {
-    public string Filename {
+    public virtual string Filename {
       get { return Headers["Content-Disposition"]["filename"].NotEmpty(Headers["Content-Disposition"]["name"]); }
     }
 
@@ -11,7 +11,7 @@ namespace AE.Net.Mail {
       get { return _ContentDisposition ?? (_ContentDisposition = Headers["Content-Disposition"].Value.ToLower()); }
     }
 
-    public bool OnServer { get; internal set; }
+    public virtual bool OnServer { get; internal set; }
 
     internal bool IsAttachment {
       get {
@@ -19,17 +19,17 @@ namespace AE.Net.Mail {
       }
     }
 
-    public void Save(string filename) {
+    public virtual void Save(string filename) {
       using (var file = new System.IO.FileStream(filename, System.IO.FileMode.Create))
         Save(file);
     }
 
-    public void Save(System.IO.Stream stream) {
+    public virtual void Save(System.IO.Stream stream) {
       var data = GetData();
       stream.Write(data, 0, data.Length);
     }
 
-    public byte[] GetData() {
+    public virtual byte[] GetData() {
       byte[] data;
       if (ContentTransferEncoding.Is("base64") && Utilities.IsValidBase64String(Body)) {
         try {

--- a/HeaderObject.cs
+++ b/HeaderObject.cs
@@ -2,9 +2,9 @@
 using System;
 namespace AE.Net.Mail {
   public abstract class ObjectWHeaders {
-    public string RawHeaders { get; internal set; }
+    public virtual string RawHeaders { get; internal set; }
     private HeaderDictionary _Headers;
-    public HeaderDictionary Headers {
+    public virtual HeaderDictionary Headers {
       get {
         return _Headers ?? (_Headers = HeaderDictionary.Parse(RawHeaders, _DefaultEncoding));
       }
@@ -13,21 +13,21 @@ namespace AE.Net.Mail {
       }
     }
 
-    public string ContentTransferEncoding {
+    public virtual string ContentTransferEncoding {
       get { return Headers["Content-Transfer-Encoding"].Value ?? string.Empty; }
       internal set {
         Headers.Set("Content-Transfer-Encoding", new HeaderValue(value));
       }
     }
 
-    public string ContentType {
+    public virtual string ContentType {
       get { return Headers["Content-Type"].Value ?? string.Empty; }
       internal set {
         Headers.Set("Content-Type", new HeaderValue(value));
       }
     }
 
-    public string Charset {
+    public virtual string Charset {
       get {
         return Headers["Content-Transfer-Encoding"]["charset"].NotEmpty(
         Headers["Content-Type"]["charset"]
@@ -37,7 +37,7 @@ namespace AE.Net.Mail {
 
     protected System.Text.Encoding _DefaultEncoding = System.Text.Encoding.GetEncoding(1252);
     protected System.Text.Encoding _Encoding;
-    public System.Text.Encoding Encoding {
+    public virtual System.Text.Encoding Encoding {
       get {
         return _Encoding ?? (_Encoding = Utilities.ParseCharsetToEncoding(Charset, _DefaultEncoding));
       }
@@ -48,7 +48,7 @@ namespace AE.Net.Mail {
       }
     }
 
-    public string Body { get; set; }
+    public virtual string Body { get; set; }
 
     internal void SetBody(string value) {
       if (ContentTransferEncoding.Is("quoted-printable")) {

--- a/Imap/Mailbox.cs
+++ b/Imap/Mailbox.cs
@@ -6,12 +6,12 @@ namespace AE.Net.Mail.Imap {
             Name = name;
             Flags = new string[0];
         }
-        public string Name { get; internal set; }
-        public int NumNewMsg { get; internal set; }
-        public int NumMsg { get; internal set; }
-        public int NumUnSeen { get; internal set; }
-        public string[] Flags { get; internal set; }
-        public bool IsWritable { get; internal set; }
+        public virtual string Name { get; internal set; }
+        public virtual int NumNewMsg { get; internal set; }
+        public virtual int NumMsg { get; internal set; }
+        public virtual int NumUnSeen { get; internal set; }
+        public virtual string[] Flags { get; internal set; }
+        public virtual bool IsWritable { get; internal set; }
 
         internal void SetFlags(string flags) {
             Flags = flags.Split(' ');

--- a/Imap/MessageEventArgs.cs
+++ b/Imap/MessageEventArgs.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace AE.Net.Mail.Imap {
     public class MessageEventArgs : EventArgs {
-        public int MessageCount { get; set; }
+        public virtual int MessageCount { get; set; }
         internal ImapClient Client { get; set; }
     }
 }

--- a/Imap/Namespace.cs
+++ b/Imap/Namespace.cs
@@ -12,13 +12,13 @@ namespace AE.Net.Mail.Imap {
         private Collection<Namespace> _usernamespace = new Collection<Namespace>();
         private Collection<Namespace> _sharednamespace = new Collection<Namespace>();
  
-        public Collection<Namespace> ServerNamespace {
+        public virtual Collection<Namespace> ServerNamespace {
             get { return this._servernamespace; }
         }
-        public Collection<Namespace> UserNamespace {
+        public virtual Collection<Namespace> UserNamespace {
             get { return this._usernamespace; }
         }
-        public Collection<Namespace> SharedNamespace {
+        public virtual Collection<Namespace> SharedNamespace {
             get { return this._sharednamespace; }
         }
     }
@@ -29,7 +29,7 @@ namespace AE.Net.Mail.Imap {
             Delimiter = delimiter;
         }
         public Namespace() { }
-        public string Prefix { get; internal set; }
-        public string Delimiter { get; internal set; }
+        public virtual string Prefix { get; internal set; }
+        public virtual string Delimiter { get; internal set; }
     }
 }

--- a/Imap/Quota.cs
+++ b/Imap/Quota.cs
@@ -13,10 +13,10 @@ namespace AE.Net.Mail.Imap {
             this.used = used;
             this.max = max;
         }
-        public int Used {
+        public virtual int Used {
             get { return this.used; }
         }
-        public int Max {
+        public virtual int Max {
             get { return this.max; }
         }
     }

--- a/Imap/SearchCondition.cs
+++ b/Imap/SearchCondition.cs
@@ -34,8 +34,8 @@ namespace AE.Net.Mail {
     public static SearchCondition Unflagged() { return new SearchCondition { Field = Fields.Unflagged }; }
     public static SearchCondition Unseen() { return new SearchCondition { Field = Fields.Unseen }; }
 
-    public object Value { get; set; }
-    public Fields? Field { get; set; }
+    public virtual object Value { get; set; }
+    public virtual Fields? Field { get; set; }
 
     public enum Fields {
       BCC, Before, Body, Cc, From, Header, Keyword,
@@ -57,15 +57,15 @@ namespace AE.Net.Mail {
       return left;
     }
 
-    public SearchCondition And(params SearchCondition[] other) {
+    public virtual SearchCondition And(params SearchCondition[] other) {
       return Join(string.Empty, this, other);
     }
 
-    public SearchCondition Not(params SearchCondition[] other) {
+    public virtual SearchCondition Not(params SearchCondition[] other) {
       return Join("NOT", this, other);
     }
 
-    public SearchCondition Or(params SearchCondition[] other) {
+    public virtual SearchCondition Or(params SearchCondition[] other) {
       return Join("OR", this, other);
     }
 

--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -33,19 +33,19 @@ namespace AE.Net.Mail {
       SaslOAuth
     }
 
-    public AuthMethods AuthMethod { get; set; }
+    public virtual AuthMethods AuthMethod { get; set; }
 
     private string GetTag() {
       _tag++;
       return string.Format("xm{0:000} ", _tag);
     }
 
-    public bool Supports(string command) {
+    public virtual bool Supports(string command) {
       return (_Capability ?? Capability()).Contains(command, StringComparer.OrdinalIgnoreCase);
     }
 
     private EventHandler<MessageEventArgs> _NewMessage;
-    public event EventHandler<MessageEventArgs> NewMessage {
+    public virtual event EventHandler<MessageEventArgs> NewMessage {
       add {
         _NewMessage += value;
         IdleStart();
@@ -58,7 +58,7 @@ namespace AE.Net.Mail {
     }
 
     private EventHandler<MessageEventArgs> _MessageDeleted;
-    public event EventHandler<MessageEventArgs> MessageDeleted {
+    public virtual event EventHandler<MessageEventArgs> MessageDeleted {
       add {
         _MessageDeleted += value;
         IdleStart();
@@ -128,7 +128,7 @@ namespace AE.Net.Mail {
       }
     }
 
-    public bool TryGetResponse(out string response, int millisecondsTimeout) {
+    public virtual bool TryGetResponse(out string response, int millisecondsTimeout) {
       var mre = new System.Threading.ManualResetEventSlim(false);
       string resp = response = null;
       ThreadPool.QueueUserWorkItem(_ => {
@@ -180,7 +180,7 @@ namespace AE.Net.Mail {
       }
     }
 
-    public void AppendMail(MailMessage email, string mailbox = null) {
+    public virtual void AppendMail(MailMessage email, string mailbox = null) {
       IdlePause();
 
       string flags = String.Empty;
@@ -205,7 +205,7 @@ namespace AE.Net.Mail {
       IdleResume();
     }
 
-    public void Noop() {
+    public virtual void Noop() {
       Noop(true);
     }
     private void Noop(bool pauseIdle) {
@@ -226,7 +226,7 @@ namespace AE.Net.Mail {
         IdleResumeCommand();
     }
 
-    public string[] Capability() {
+    public virtual string[] Capability() {
       IdlePause();
       string command = GetTag() + "CAPABILITY";
       string response = SendCommandGetResponse(command);
@@ -238,7 +238,7 @@ namespace AE.Net.Mail {
       return _Capability;
     }
 
-    public void Copy(string messageset, string destination) {
+    public virtual void Copy(string messageset, string destination) {
       CheckMailboxSelected();
       IdlePause();
       string prefix = null;
@@ -251,21 +251,21 @@ namespace AE.Net.Mail {
       IdleResume();
     }
 
-    public void CreateMailbox(string mailbox) {
+    public virtual void CreateMailbox(string mailbox) {
       IdlePause();
       string command = GetTag() + "CREATE " + mailbox.QuoteString();
       SendCommandCheckOK(command);
       IdleResume();
     }
 
-    public void DeleteMailbox(string mailbox) {
+    public virtual void DeleteMailbox(string mailbox) {
       IdlePause();
       string command = GetTag() + "DELETE " + mailbox.QuoteString();
       SendCommandCheckOK(command);
       IdleResume();
     }
 
-    public Mailbox Examine(string mailbox) {
+    public virtual Mailbox Examine(string mailbox) {
       IdlePause();
 
       Mailbox x = null;
@@ -295,7 +295,7 @@ namespace AE.Net.Mail {
       return x;
     }
 
-    public void Expunge() {
+    public virtual void Expunge() {
       CheckMailboxSelected();
       IdlePause();
 
@@ -308,16 +308,16 @@ namespace AE.Net.Mail {
       IdleResume();
     }
 
-    public void DeleteMessage(AE.Net.Mail.MailMessage msg) {
+    public virtual void DeleteMessage(AE.Net.Mail.MailMessage msg) {
       DeleteMessage(msg.Uid);
     }
 
-    public void DeleteMessage(string uid) {
+    public virtual void DeleteMessage(string uid) {
       CheckMailboxSelected();
       Store("UID " + uid, true, "\\Seen \\Deleted");
     }
 
-    public void MoveMessage(string uid, string folderName) {
+    public virtual void MoveMessage(string uid, string folderName) {
       CheckMailboxSelected();
       Copy("UID " + uid, folderName);
       DeleteMessage(uid);
@@ -328,27 +328,27 @@ namespace AE.Net.Mail {
         SelectMailbox("INBOX");
     }
 
-    public MailMessage GetMessage(string uid, bool headersonly = false) {
+    public virtual MailMessage GetMessage(string uid, bool headersonly = false) {
       return GetMessage(uid, headersonly, true);
     }
 
-    public MailMessage GetMessage(int index, bool headersonly = false) {
+    public virtual MailMessage GetMessage(int index, bool headersonly = false) {
       return GetMessage(index, headersonly, true);
     }
 
-    public MailMessage GetMessage(int index, bool headersonly, bool setseen) {
+    public virtual MailMessage GetMessage(int index, bool headersonly, bool setseen) {
       return GetMessages(index, index, headersonly, setseen).FirstOrDefault();
     }
 
-    public MailMessage GetMessage(string uid, bool headersonly, bool setseen) {
+    public virtual MailMessage GetMessage(string uid, bool headersonly, bool setseen) {
       return GetMessages(uid, uid, headersonly, setseen).FirstOrDefault();
     }
 
-    public MailMessage[] GetMessages(string startUID, string endUID, bool headersonly = true, bool setseen = false) {
+    public virtual MailMessage[] GetMessages(string startUID, string endUID, bool headersonly = true, bool setseen = false) {
       return GetMessages(startUID, endUID, true, headersonly, setseen);
     }
 
-    public MailMessage[] GetMessages(int startIndex, int endIndex, bool headersonly = true, bool setseen = false) {
+    public virtual MailMessage[] GetMessages(int startIndex, int endIndex, bool headersonly = true, bool setseen = false) {
       return GetMessages((startIndex + 1).ToString(), (endIndex + 1).ToString(), false, headersonly, setseen);
     }
 
@@ -388,7 +388,7 @@ namespace AE.Net.Mail {
       return values;
     }
 
-    public MailMessage[] GetMessages(string start, string end, bool uid, bool headersonly, bool setseen) {
+    public virtual MailMessage[] GetMessages(string start, string end, bool uid, bool headersonly, bool setseen) {
       CheckMailboxSelected();
       IdlePause();
 
@@ -454,7 +454,7 @@ namespace AE.Net.Mail {
       return x.ToArray();
     }
 
-    public Quota GetQuota(string mailbox) {
+    public virtual Quota GetQuota(string mailbox) {
       if (!Supports("NAMESPACE"))
         new Exception("This command is not supported by the server!");
       IdlePause();
@@ -480,7 +480,7 @@ namespace AE.Net.Mail {
       return quota;
     }
 
-    public Mailbox[] ListMailboxes(string reference, string pattern) {
+    public virtual Mailbox[] ListMailboxes(string reference, string pattern) {
       IdlePause();
 
       var x = new List<Mailbox>();
@@ -498,7 +498,7 @@ namespace AE.Net.Mail {
       return x.ToArray();
     }
 
-    public Mailbox[] ListSuscribesMailboxes(string reference, string pattern) {
+    public virtual Mailbox[] ListSuscribesMailboxes(string reference, string pattern) {
       IdlePause();
 
       var x = new List<Mailbox>();
@@ -578,7 +578,7 @@ namespace AE.Net.Mail {
         SendCommand(GetTag() + "LOGOUT");
     }
 
-    public Namespaces Namespace() {
+    public virtual Namespaces Namespace() {
       if (!Supports("NAMESPACE"))
         throw new NotSupportedException("This command is not supported by the server!");
       IdlePause();
@@ -618,11 +618,11 @@ namespace AE.Net.Mail {
       return n;
     }
 
-    public int GetMessageCount() {
+    public virtual int GetMessageCount() {
       CheckMailboxSelected();
       return GetMessageCount(null);
     }
-    public int GetMessageCount(string mailbox) {
+    public virtual int GetMessageCount(string mailbox) {
       IdlePause();
 
       string command = GetTag() + "STATUS " + Utilities.QuoteString(mailbox ?? _SelectedMailbox) + " (MESSAGES)";
@@ -640,7 +640,7 @@ namespace AE.Net.Mail {
       return result;
     }
 
-    public void RenameMailbox(string frommailbox, string tomailbox) {
+    public virtual void RenameMailbox(string frommailbox, string tomailbox) {
       IdlePause();
 
       string command = GetTag() + "RENAME " + frommailbox.QuoteString() + " " + tomailbox.QuoteString();
@@ -648,11 +648,11 @@ namespace AE.Net.Mail {
       IdleResume();
     }
 
-    public string[] Search(SearchCondition criteria, bool uid = true) {
+    public virtual string[] Search(SearchCondition criteria, bool uid = true) {
       return Search(criteria.ToString(), uid);
     }
 
-    public string[] Search(string criteria, bool uid = true) {
+    public virtual string[] Search(string criteria, bool uid = true) {
       CheckMailboxSelected();
 
       string isuid = uid ? "UID " : "";
@@ -673,13 +673,13 @@ namespace AE.Net.Mail {
       return m.Groups[1].Value.Trim().Split(' ').Where(x => !string.IsNullOrEmpty(x)).ToArray();
     }
 
-    public Lazy<MailMessage>[] SearchMessages(SearchCondition criteria, bool headersonly = false) {
+    public virtual Lazy<MailMessage>[] SearchMessages(SearchCondition criteria, bool headersonly = false) {
       return Search(criteria, true)
           .Select(x => new Lazy<MailMessage>(() => GetMessage(x, headersonly)))
           .ToArray();
     }
 
-    public Mailbox SelectMailbox(string mailbox) {
+    public virtual Mailbox SelectMailbox(string mailbox) {
       IdlePause();
 
       Mailbox x = null;
@@ -714,11 +714,11 @@ namespace AE.Net.Mail {
       return x;
     }
 
-    public void SetFlags(Flags flags, params MailMessage[] msgs) {
+    public virtual void SetFlags(Flags flags, params MailMessage[] msgs) {
       SetFlags(FlagsToFlagString(flags), msgs);
     }
 
-    public void SetFlags(string flags, params MailMessage[] msgs) {
+    public virtual void SetFlags(string flags, params MailMessage[] msgs) {
       Store("UID " + string.Join(" ", msgs.Select(x => x.Uid)), true, flags);
       foreach (var msg in msgs) {
         msg.SetFlags(flags);
@@ -731,18 +731,18 @@ namespace AE.Net.Mail {
     }
 
 
-    public void AddFlags(Flags flags, params MailMessage[] msgs) {
+    public virtual void AddFlags(Flags flags, params MailMessage[] msgs) {
       AddFlags(FlagsToFlagString(flags), msgs);
     }
 
-    public void AddFlags(string flags, params MailMessage[] msgs) {
+    public virtual void AddFlags(string flags, params MailMessage[] msgs) {
       Store("UID " + string.Join(" ", msgs.Select(x => x.Uid)), false, flags);
       foreach (var msg in msgs) {
           msg.SetFlags(FlagsToFlagString(msg.Flags) + " " + flags);
       }
     }
 
-    public void Store(string messageset, bool replace, string flags) {
+    public virtual void Store(string messageset, bool replace, string flags) {
       CheckMailboxSelected();
       IdlePause();
       string prefix = null;
@@ -760,7 +760,7 @@ namespace AE.Net.Mail {
       IdleResume();
     }
 
-    public void SuscribeMailbox(string mailbox) {
+    public virtual void SuscribeMailbox(string mailbox) {
       IdlePause();
 
       string command = GetTag() + "SUBSCRIBE " + mailbox.QuoteString();
@@ -768,7 +768,7 @@ namespace AE.Net.Mail {
       IdleResume();
     }
 
-    public void UnSuscribeMailbox(string mailbox) {
+    public virtual void UnSuscribeMailbox(string mailbox) {
       IdlePause();
 
       string command = GetTag() + "UNSUBSCRIBE " + mailbox.QuoteString();

--- a/MailMessage.cs
+++ b/MailMessage.cs
@@ -57,31 +57,31 @@ namespace AE.Net.Mail {
       AlternateViews = new List<Attachment>();
     }
 
-    public DateTime Date { get; set; }
-    public string[] RawFlags { get; set; }
-    public Flags Flags { get; set; }
+    public virtual DateTime Date { get; set; }
+    public virtual string[] RawFlags { get; set; }
+    public virtual Flags Flags { get; set; }
 
-    public int Size { get; internal set; }
-    public string Subject { get; set; }
-    public ICollection<MailAddress> To { get; private set; }
-    public ICollection<MailAddress> Cc { get; private set; }
-    public ICollection<MailAddress> Bcc { get; private set; }
-    public ICollection<MailAddress> ReplyTo { get; private set; }
-    public ICollection<Attachment> Attachments { get; set; }
-    public ICollection<Attachment> AlternateViews { get; set; }
-    public MailAddress From { get; set; }
-    public MailAddress Sender { get; set; }
-    public string MessageID { get; set; }
-    public string Uid { get; internal set; }
-    public MailPriority Importance { get; set; }
+    public virtual int Size { get; internal set; }
+    public virtual string Subject { get; set; }
+    public virtual ICollection<MailAddress> To { get; private set; }
+    public virtual ICollection<MailAddress> Cc { get; private set; }
+    public virtual ICollection<MailAddress> Bcc { get; private set; }
+    public virtual ICollection<MailAddress> ReplyTo { get; private set; }
+    public virtual ICollection<Attachment> Attachments { get; set; }
+    public virtual ICollection<Attachment> AlternateViews { get; set; }
+    public virtual MailAddress From { get; set; }
+    public virtual MailAddress Sender { get; set; }
+    public virtual string MessageID { get; set; }
+    public virtual string Uid { get; internal set; }
+    public virtual MailPriority Importance { get; set; }
 
-    public void Load(string message, bool headersOnly = false) {
+    public virtual void Load(string message, bool headersOnly = false) {
       using (var mem = new MemoryStream(_DefaultEncoding.GetBytes(message))) {
         Load(mem, headersOnly, 0);
       }
     }
 
-    public void Load(Stream reader, bool headersOnly = false, int maxLength = 0) {
+    public virtual void Load(Stream reader, bool headersOnly = false, int maxLength = 0) {
       _HeadersOnly = headersOnly;
       Headers = null;
       Body = null;
@@ -199,13 +199,13 @@ namespace AE.Net.Mail {
       }).Sum();
     }
 
-    public void Save(System.IO.Stream stream, Encoding encoding = null) {
+    public virtual void Save(System.IO.Stream stream, Encoding encoding = null) {
       using (var str = new System.IO.StreamWriter(stream, encoding ?? System.Text.Encoding.Default))
         Save(str);
     }
 
     private static readonly string[] SpecialHeaders = "Date,To,Cc,Reply-To,Bcc,Sender,From,Message-ID,Importance,Subject".Split(',');
-    public void Save(System.IO.TextWriter txt) {
+    public virtual void Save(System.IO.TextWriter txt) {
       txt.WriteLine("Date: {0}", Date.GetRFC2060Date());
       txt.WriteLine("To: ", string.Join("; ", To.Select(x => x.ToString())));
       txt.WriteLine("Cc: ", string.Join("; ", Cc.Select(x => x.ToString())));

--- a/Pop3Client.cs
+++ b/Pop3Client.cs
@@ -27,14 +27,14 @@ namespace AE.Net.Mail {
       }
     }
 
-    public int GetMessageCount() {
+    public virtual int GetMessageCount() {
       CheckConnectionStatus();
       var result = SendCommandGetResponse("STAT");
       CheckResultOK(result);
       return int.Parse(result.Split(' ')[1]);
     }
 
-    //public string[] GetMessageIDs() {
+    //public virtual string[] GetMessageIDs() {
     //    CheckConnectionStatus();
     //    string result = SendCommandGetResponse("LIST");
     //    List<string> ids = new List<string>();
@@ -48,12 +48,12 @@ namespace AE.Net.Mail {
     //    return ids.ToArray();
     //}
 
-    public MailMessage GetMessage(int index, bool headersOnly = false) {
+    public virtual MailMessage GetMessage(int index, bool headersOnly = false) {
       return GetMessage((index + 1).ToString(), headersOnly);
     }
 
     private static Regex rxOctets = new Regex(@"(\d+)\s+octets", RegexOptions.IgnoreCase);
-    public MailMessage GetMessage(string uid, bool headersOnly = false) {
+    public virtual MailMessage GetMessage(string uid, bool headersOnly = false) {
       CheckConnectionStatus();
       var result = new StringBuilder();
       string line = SendCommandGetResponse(string.Format(headersOnly ? "TOP {0} 0" : "RETR {0}", uid));
@@ -68,16 +68,16 @@ namespace AE.Net.Mail {
       return msg;
     }
 
-    public void DeleteMessage(string uid) {
+    public virtual void DeleteMessage(string uid) {
       SendCommandCheckOK("DELE " + uid);
 
     }
 
-    public void DeleteMessage(int index) {
+    public virtual void DeleteMessage(int index) {
       DeleteMessage((index + 1).ToString());
     }
 
-    public void DeleteMessage(AE.Net.Mail.MailMessage msg) {
+    public virtual void DeleteMessage(AE.Net.Mail.MailMessage msg) {
       DeleteMessage(msg.Uid);
     }
   }

--- a/TextClient.cs
+++ b/TextClient.cs
@@ -7,13 +7,13 @@ namespace AE.Net.Mail {
     protected TcpClient _Connection;
     protected Stream _Stream;
 
-    public string Host { get; private set; }
-    public int Port { get; set; }
-    public bool Ssl { get; set; }
-    public bool IsConnected { get; private set; }
-    public bool IsAuthenticated { get; private set; }
-    public bool IsDisposed { get; private set; }
-    public System.Text.Encoding Encoding { get; set; }
+    public virtual string Host { get; private set; }
+    public virtual int Port { get; set; }
+    public virtual bool Ssl { get; set; }
+    public virtual bool IsConnected { get; private set; }
+    public virtual bool IsAuthenticated { get; private set; }
+    public virtual bool IsDisposed { get; private set; }
+    public virtual System.Text.Encoding Encoding { get; set; }
 
     public TextClient() {
       Encoding = System.Text.Encoding.GetEncoding(1252);
@@ -29,7 +29,7 @@ namespace AE.Net.Mail {
 
     protected virtual void OnDispose() { }
 
-    public void Login(string username, string password) {
+    public virtual void Login(string username, string password) {
       if (!IsConnected) {
         throw new Exception("You must connect first!");
       }
@@ -38,20 +38,20 @@ namespace AE.Net.Mail {
       IsAuthenticated = true;
     }
 
-    public void Logout() {
+    public virtual void Logout() {
       IsAuthenticated = false;
       OnLogout();
     }
 
 
-    public void Connect(string hostname, int port, bool ssl, bool skipSslValidation) {
+    public virtual void Connect(string hostname, int port, bool ssl, bool skipSslValidation) {
       System.Net.Security.RemoteCertificateValidationCallback validateCertificate = null;
       if (skipSslValidation)
         validateCertificate = (sender, cert, chain, err) => true;
       Connect(hostname, port, ssl, validateCertificate);
     }
 
-    public void Connect(string hostname, int port, bool ssl, System.Net.Security.RemoteCertificateValidationCallback validateCertificate) {
+    public virtual void Connect(string hostname, int port, bool ssl, System.Net.Security.RemoteCertificateValidationCallback validateCertificate) {
       try {
         Host = hostname;
         Port = port;
@@ -80,7 +80,7 @@ namespace AE.Net.Mail {
       }
     }
 
-    protected void CheckConnectionStatus() {
+    protected virtual void CheckConnectionStatus() {
       if (IsDisposed)
         throw new ObjectDisposedException(this.GetType().Name);
       if (!IsConnected)
@@ -94,7 +94,7 @@ namespace AE.Net.Mail {
       _Stream.Write(bytes, 0, bytes.Length);
     }
 
-    protected string SendCommandGetResponse(string command) {
+    protected virtual string SendCommandGetResponse(string command) {
       SendCommand(command);
       return GetResponse();
     }
@@ -115,11 +115,11 @@ namespace AE.Net.Mail {
       }
     }
 
-    protected void SendCommandCheckOK(string command) {
+    protected virtual void SendCommandCheckOK(string command) {
       CheckResultOK(SendCommandGetResponse(command));
     }
 
-    public void Disconnect() {
+    public virtual void Disconnect() {
       if (IsAuthenticated)
         Logout();
 
@@ -127,7 +127,7 @@ namespace AE.Net.Mail {
       Utilities.TryDispose(ref _Connection);
     }
 
-    public void Dispose() {
+    public virtual void Dispose() {
       if (IsDisposed) return;
       lock (this) {
         if (IsDisposed) return;


### PR DESCRIPTION
All public and protected methods and properties marked as virtual. This is to allow mocking/stubbing of classes in the library for testing purposes.
