### PR TITLE
Re-ordering of header processing to prevent gmail headers being lost

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -422,10 +422,10 @@ namespace AE.Net.Mail {
 					mail.SetFlags(imapHeaders["Flags"]);
 
 
-				foreach (var key in imapHeaders.AllKeys.Except(new[] { "UID", "Flags", "BODY[]", "BODY[HEADER]" }, StringComparer.OrdinalIgnoreCase))
-					mail.Headers.Add(key, new HeaderValue(imapHeaders[key]));
-
 				mail.Load(_Stream, headersonly, mail.Size);
+
+                foreach (var key in imapHeaders.AllKeys.Except(new[] { "UID", "Flags", "BODY[]", "BODY[HEADER]" }, StringComparer.OrdinalIgnoreCase))
+                    mail.Headers.Add(key, new HeaderValue(imapHeaders[key]));
 
 				var n = Convert.ToChar(_Stream.ReadByte());
 				System.Diagnostics.Debug.Assert(n == ')');


### PR DESCRIPTION
The gmail thread ID was being lost because the MailMessage.Headers were being set to null in the Load method after the custom headers had been added.

It looks like a more significant refactor would be good, perhaps making the MailMessage immutable.

But for now, this seems to work fine.

This is my first ever pull request. Any feedback welcome.
