### PR TITLE
Mailbox International Naming Convention

### DIFF
--- a/AE.Net.Mail.csproj
+++ b/AE.Net.Mail.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attachment.cs" />
+    <Compile Include="Imap\ModifiedUtf7Encoding.cs" />
     <Compile Include="Imap\SearchCondition.cs" />
     <Compile Include="HeaderCollection.cs" />
     <Compile Include="HeaderObject.cs" />

--- a/Imap/Mailbox.cs
+++ b/Imap/Mailbox.cs
@@ -3,7 +3,7 @@ namespace AE.Net.Mail.Imap {
     public class Mailbox {
         public Mailbox() : this(string.Empty) { }
         public Mailbox(string name) {
-            Name = name;
+            Name = ModifiedUtf7Encoding.Decode(name);
             Flags = new string[0];
         }
         public virtual string Name { get; internal set; }

--- a/Imap/ModifiedUtf7Encoding.cs
+++ b/Imap/ModifiedUtf7Encoding.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AE.Net.Mail.Imap
+{
+    public static class ModifiedUtf7Encoding {
+        /// <summary>
+        /// Decodes modified UTF-7 according to RFC 3501 5.1.3: Mailbox International Naming Convention
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Decode(string input) {
+            if (String.IsNullOrWhiteSpace(input)) {
+                return input;
+            }
+
+            string result = input.Replace("&-", "&");
+
+            for (int indexOfAmpersand = result.IndexOf('&'); indexOfAmpersand != -1; indexOfAmpersand = result.IndexOf('&', indexOfAmpersand + 1)) {
+                int indexOfMinus = result.IndexOf('-', indexOfAmpersand);
+                if (indexOfMinus > 0) {
+                    string substring = result.Substring(indexOfAmpersand + 1, indexOfMinus - indexOfAmpersand - 1);
+                    string modifiedBase64 = "+" + substring.Replace(',', '/');
+                    result = result.Replace("&" + substring + "-", Encoding.UTF7.GetString(Encoding.UTF8.GetBytes(modifiedBase64)));
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Encodes to modified UTF-7 according to RFC 3501 5.1.3: Mailbox International Naming Convention
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Encode(string input) {
+            if (String.IsNullOrWhiteSpace(input)) {
+                return input;
+            }
+
+            if (input.All(IsPrintableAscii)) {
+                return input.Replace("&", "&-");
+            }
+
+            var result = new StringBuilder();
+            var nonAsciiBuffer = new StringBuilder();
+            foreach (char c in input) {
+                if (IsPrintableAscii(c)) {
+                    if (nonAsciiBuffer.Length > 0) {
+                        result.Append(EncodeNonPrintableAsciiString(nonAsciiBuffer.ToString()));
+                        nonAsciiBuffer.Clear();
+                    }
+
+                    if (c == '&') {
+                        result.Append("&-");
+                    }
+                    else {
+                        result.Append(c);
+                    }
+                }
+                else {
+                    nonAsciiBuffer.Append(c);
+                }
+            }
+
+            if (result.Length == 0 && nonAsciiBuffer.Length > 0) {
+                result.Append(EncodeNonPrintableAsciiString(nonAsciiBuffer.ToString()));
+            }
+
+            return result.ToString();
+        }
+
+        private static string EncodeNonPrintableAsciiString(string nonAsciiString) {
+            return Encoding.UTF8.GetString(Encoding.UTF7.GetBytes(nonAsciiString)).Replace('/', ',').Replace('+', '&');
+        }
+
+        private static bool IsPrintableAscii(char c) {
+            return c >= '\x20' && c <= '\x7e';
+        }
+    }
+
+}

--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -183,6 +183,7 @@ namespace AE.Net.Mail {
 		public virtual void AppendMail(MailMessage email, string mailbox = null) {
 			IdlePause();
 
+		    mailbox = ModifiedUtf7Encoding.Encode(mailbox);
 			string flags = String.Empty;
 			var body = new StringBuilder();
 			using (var txt = new System.IO.StringWriter(body))
@@ -253,14 +254,14 @@ namespace AE.Net.Mail {
 
 		public virtual void CreateMailbox(string mailbox) {
 			IdlePause();
-			string command = GetTag() + "CREATE " + mailbox.QuoteString();
+			string command = GetTag() + "CREATE " + ModifiedUtf7Encoding.Encode(mailbox).QuoteString();
 			SendCommandCheckOK(command);
 			IdleResume();
 		}
 
 		public virtual void DeleteMailbox(string mailbox) {
 			IdlePause();
-			string command = GetTag() + "DELETE " + mailbox.QuoteString();
+            string command = GetTag() + "DELETE " + ModifiedUtf7Encoding.Encode(mailbox).QuoteString();
 			SendCommandCheckOK(command);
 			IdleResume();
 		}
@@ -270,7 +271,7 @@ namespace AE.Net.Mail {
 
 			Mailbox x = null;
 			string tag = GetTag();
-			string command = tag + "EXAMINE " + mailbox.QuoteString();
+            string command = tag + "EXAMINE " + ModifiedUtf7Encoding.Encode(mailbox).QuoteString();
 			string response = SendCommandGetResponse(command);
 			if (response.StartsWith("*")) {
 				x = new Mailbox(mailbox);
@@ -443,7 +444,7 @@ namespace AE.Net.Mail {
 			IdlePause();
 
 			Quota quota = null;
-			string command = GetTag() + "GETQUOTAROOT " + mailbox.QuoteString();
+            string command = GetTag() + "GETQUOTAROOT " + ModifiedUtf7Encoding.Encode(mailbox).QuoteString();
 			string response = SendCommandGetResponse(command);
 			string reg = "\\* QUOTA (.*?) \\((.*?) (.*?) (.*?)\\)";
 			while (response.StartsWith("*")) {
@@ -608,7 +609,7 @@ namespace AE.Net.Mail {
 		public virtual int GetMessageCount(string mailbox) {
 			IdlePause();
 
-			string command = GetTag() + "STATUS " + Utilities.QuoteString(mailbox ?? _SelectedMailbox) + " (MESSAGES)";
+			string command = GetTag() + "STATUS " + Utilities.QuoteString(ModifiedUtf7Encoding.Encode(mailbox) ?? _SelectedMailbox) + " (MESSAGES)";
 			string response = SendCommandGetResponse(command);
 			string reg = @"\* STATUS.*MESSAGES (\d+)";
 			int result = 0;
@@ -665,9 +666,10 @@ namespace AE.Net.Mail {
 		public virtual Mailbox SelectMailbox(string mailbox) {
 			IdlePause();
 
+		    mailbox = ModifiedUtf7Encoding.Encode(mailbox);
 			Mailbox x = null;
 			string tag = GetTag();
-			string command = tag + "SELECT " + mailbox.QuoteString();
+            string command = tag + "SELECT " + mailbox.QuoteString();
 			string response = SendCommandGetResponse(command);
 			if (response.StartsWith("*")) {
 				x = new Mailbox(mailbox);
@@ -745,7 +747,7 @@ namespace AE.Net.Mail {
 		public virtual void SuscribeMailbox(string mailbox) {
 			IdlePause();
 
-			string command = GetTag() + "SUBSCRIBE " + mailbox.QuoteString();
+            string command = GetTag() + "SUBSCRIBE " + ModifiedUtf7Encoding.Encode(mailbox).QuoteString();
 			SendCommandCheckOK(command);
 			IdleResume();
 		}
@@ -753,7 +755,7 @@ namespace AE.Net.Mail {
 		public virtual void UnSuscribeMailbox(string mailbox) {
 			IdlePause();
 
-			string command = GetTag() + "UNSUBSCRIBE " + mailbox.QuoteString();
+            string command = GetTag() + "UNSUBSCRIBE " + ModifiedUtf7Encoding.Encode(mailbox).QuoteString();
 			SendCommandCheckOK(command);
 			IdleResume();
 		}

--- a/Tests/ModifiedUtf7EncodingTest.cs
+++ b/Tests/ModifiedUtf7EncodingTest.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using AE.Net.Mail.Imap;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Shouldly;
+
+namespace Tests
+{
+    [TestClass]
+    public class ModifiedUtf7EncodingTest {
+
+        [TestMethod]
+        public void Decode_AsciiOnlyInput_ReturnsOriginalString() {
+            string mailboxNameWithAsciiOnly = "Sent";
+
+            string result = ModifiedUtf7Encoding.Decode(mailboxNameWithAsciiOnly);
+
+            result.ShouldBe(mailboxNameWithAsciiOnly);
+        }
+
+        [TestMethod]
+        public void Decode_InputWithEncodedUmlaut_ReturnsStringWithDecodedUmlaut() {
+            string mailboxNameWithUmlaut = "Entw&APw-rfe";
+
+            string result = ModifiedUtf7Encoding.Decode(mailboxNameWithUmlaut);
+
+            result.ShouldBe("Entwürfe");
+        }
+
+        [TestMethod]
+        public void Decode_InputWithEncodedCyrillicCharacters_ReturnsDecodedCyrillicCharacters() {
+            string mailboxNameWithCyrillicCharacters = "&BB4EQgQ,BEAEMAQyBDsENQQ9BD0ESwQ1-";
+
+            string result = ModifiedUtf7Encoding.Decode(mailboxNameWithCyrillicCharacters);
+
+            result.ShouldBe("Отправленные");
+        }
+
+        [TestMethod]
+        public void Decode_InputWithConventionalAmpersand_ReturnsStringWithDecodedAmpersand() {
+            string mailboxWithAmpersand = "Test &- Test";
+
+            string result = ModifiedUtf7Encoding.Decode(mailboxWithAmpersand);
+
+            result.ShouldBe("Test & Test");
+        }
+
+        [TestMethod]
+        public void Decode_InputNull_ReturnsNull() {
+            ModifiedUtf7Encoding.Decode(null).ShouldBe(null);
+        }
+
+        [TestMethod]
+        public void Encode_AsciiOnlyInput_ReturnsOriginalString() {
+            string mailboxNameWithAsciiOnly = "Sent";
+
+            string result = ModifiedUtf7Encoding.Encode(mailboxNameWithAsciiOnly);
+
+            result.ShouldBe(mailboxNameWithAsciiOnly);
+        }
+
+        [TestMethod]
+        public void Encode_InputWithUmlaut_ReturnsStringWithEncodedUmlaut() {
+            string mailboxNameWithUmlaut = "Entwürfe";
+
+            string result = ModifiedUtf7Encoding.Encode(mailboxNameWithUmlaut);
+
+            result.ShouldBe("Entw&APw-rfe");
+        }
+
+        [TestMethod]
+        public void Encode_InputWithCyrillicCharacters_ReturnsStringWithEncodedCyrillicCharacters() {
+            string mailboxNameWithCyrillicCharacters = "Отправленные";
+
+            string result = ModifiedUtf7Encoding.Encode(mailboxNameWithCyrillicCharacters);
+
+            result.ShouldBe("&BB4EQgQ,BEAEMAQyBDsENQQ9BD0ESwQ1-");
+        }
+
+        [TestMethod]
+        public void Encode_InputWithConventionalAmpersand_ReturnsStringWithAmpersandMinus() {
+            string mailboxWithAmpersand = "Test & Test";
+
+            string result = ModifiedUtf7Encoding.Encode(mailboxWithAmpersand);
+
+            result.ShouldBe("Test &- Test");
+        }
+
+        [TestMethod]
+        public void Encode_InputNull_ReturnsNull() {
+            ModifiedUtf7Encoding.Encode(null).ShouldBe(null);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -50,6 +50,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ModifiedUtf7EncodingTest.cs" />
     <Compile Include="Parsing.cs" />
     <Compile Include="ParseSpam.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Implemented RFC 3501 section 5.1.3, making it possible to correctly
display mailboxes with non-printable ASCII characters.

It should fix Issue #114.
