### PR TITLE
Make sure the GetMailAddresses function parses DisplayNames containing a comma correctly

### DIFF
--- a/MailMessage.cs
+++ b/MailMessage.cs
@@ -130,12 +130,12 @@ namespace AE.Net.Mail {
 			}
 
 			Date = Headers.GetDate();
-			To = Headers.GetAddresses("To").ToList();
-			Cc = Headers.GetAddresses("Cc").ToList();
-			Bcc = Headers.GetAddresses("Bcc").ToList();
-			Sender = Headers.GetAddresses("Sender").FirstOrDefault();
-			ReplyTo = Headers.GetAddresses("Reply-To").ToList();
-			From = Headers.GetAddresses("From").FirstOrDefault();
+			To = Headers.GetMailAddresses("To").ToList();
+			Cc = Headers.GetMailAddresses("Cc").ToList();
+			Bcc = Headers.GetMailAddresses("Bcc").ToList();
+			Sender = Headers.GetMailAddresses("Sender").FirstOrDefault();
+			ReplyTo = Headers.GetMailAddresses("Reply-To").ToList();
+			From = Headers.GetMailAddresses("From").FirstOrDefault();
 			MessageID = Headers["Message-ID"].RawValue;
 
 			Importance = Headers.GetEnum<MailPriority>("Importance");

--- a/Tests/HeaderDictionary.cs
+++ b/Tests/HeaderDictionary.cs
@@ -1,0 +1,244 @@
+﻿using System.Linq;
+using AE.Net.Mail;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests
+{
+    [TestClass]
+    public class HeaderDictionaryTests
+    {
+        [TestMethod]
+        public void GetAddresses_EmptyHeader_ReturnsNoEmailAddresses()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@"")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(0, mailAddresses.Length);
+        }
+
+        [TestMethod]
+        public void GetAddresses_Rubbish_ReturnsNoEmailAddresses()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@"<<<<,783459@")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(0, mailAddresses.Length);
+        }
+
+        [TestMethod]
+        public void GetAddresses_OnlyOneSemicolon_ReturnsNoEmailAddresses()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@";")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(0, mailAddresses.Length);
+        }
+
+        [TestMethod]
+        public void GetAddresses_OnlyOneComma_ReturnsNoEmailAddresses()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@",")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(0, mailAddresses.Length);
+        }
+
+        [TestMethod]
+        public void GetAddresses_FiveCommasOnly_ReturnsNoEmailAddresses()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@",,,,,")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(0, mailAddresses.Length);
+        }
+
+        [TestMethod]
+        public void GetAddresses_Spaces_ReturnsNoEmailAddresses()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@"    ")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(0, mailAddresses.Length);
+        }
+
+        [TestMethod]
+        public void GetAddresses_SimpleWithQuotesAroundDisplayName_ParsesCorrectAddressAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@"""name"" <name@domain.net>")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(1, mailAddresses.Length);
+
+            var mailAddress = mailAddresses.First();
+            Assert.AreEqual("name@domain.net", mailAddress.Address);
+            Assert.AreEqual("name", mailAddress.DisplayName);
+        }
+
+        [TestMethod]
+        public void GetAddresses_SimpleWithoutQuotesAroundDisplayName_ParsesCorrectAddressAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@"Test van Testenstein <test@domain.net>")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(1, mailAddresses.Length);
+
+            var mailAddress = mailAddresses.First();
+            Assert.AreEqual("test@domain.net", mailAddress.Address);
+            Assert.AreEqual("Test van Testenstein", mailAddress.DisplayName);
+        }
+
+        [TestMethod]
+        public void GetAddresses_PipelineInDisplayName_ParsesCorrectAddressAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@"Test | Testenstein <test@domain.net>")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(1, mailAddresses.Length);
+
+            var mailAddress = mailAddresses.First();
+            Assert.AreEqual("test@domain.net", mailAddress.Address);
+            Assert.AreEqual("Test | Testenstein", mailAddress.DisplayName);
+        }
+
+        [TestMethod]
+        public void GetAddresses_WithCommaInDispayName_ParsesCorrectAddressAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "From", new HeaderValue(@"""lastname, firstname"" <firstname.lastname@domain.net>")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("From");
+
+            Assert.AreEqual(1, mailAddresses.Length);
+
+            var mailAddress = mailAddresses.First();
+            Assert.AreEqual("firstname.lastname@domain.net", mailAddress.Address);
+            Assert.AreEqual("lastname, firstname", mailAddress.DisplayName);
+        }
+
+        [TestMethod]
+        public void GetAddresses_WithTwoAddresses_ParsesCorrectAddressesAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "To", new HeaderValue(@"Firstname Lastname <first@domain.net>, second.address@domain.net")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("To");
+
+            Assert.AreEqual(2, mailAddresses.Length);
+
+            var firstMailAddress = mailAddresses.First();
+            Assert.AreEqual("first@domain.net", firstMailAddress.Address);
+            Assert.AreEqual("Firstname Lastname", firstMailAddress.DisplayName);
+
+            var secondMailAddress = mailAddresses.Last();
+            Assert.AreEqual("second.address@domain.net", secondMailAddress.Address);
+            Assert.AreEqual("", secondMailAddress.DisplayName);
+        }
+
+        [TestMethod]
+        public void GetAddresses_WithTwoAddressesWithCommaInSecondEmail_ParsesCorrectAddressesAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "To", new HeaderValue(@"Firstname Lastname <first@domain.net>, ""Test, 2"" <second.address@domain.net>")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("To");
+
+            Assert.AreEqual(2, mailAddresses.Length);
+
+            var firstMailAddress = mailAddresses.First();
+            Assert.AreEqual("first@domain.net", firstMailAddress.Address);
+            Assert.AreEqual("Firstname Lastname", firstMailAddress.DisplayName);
+
+            var secondMailAddress = mailAddresses.Last();
+            Assert.AreEqual("second.address@domain.net", secondMailAddress.Address);
+            Assert.AreEqual("Test, 2", secondMailAddress.DisplayName);
+        }
+
+        [TestMethod]
+        public void GetAddresses_WithTwoAddressesWithCommaInSecondEmailAndTrailingComma_ParsesCorrectAddressesAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "To", new HeaderValue(@"Firstname Lastname <first@domain.net>, ""Test, 2"" <second.address@domain.net>, ")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("To");
+
+            Assert.AreEqual(2, mailAddresses.Length);
+
+            var firstMailAddress = mailAddresses.First();
+            Assert.AreEqual("first@domain.net", firstMailAddress.Address);
+            Assert.AreEqual("Firstname Lastname", firstMailAddress.DisplayName);
+
+            var secondMailAddress = mailAddresses.Last();
+            Assert.AreEqual("second.address@domain.net", secondMailAddress.Address);
+            Assert.AreEqual("Test, 2", secondMailAddress.DisplayName);
+        }
+
+        [TestMethod]
+        public void GetAddresses_WithThreeAddresses_ParsesCorrectAddressesAndDisplayName()
+        {
+            var headerDictionary = new HeaderDictionary
+                {
+                    { "To", new HeaderValue(@"<test1@domain.net>,   <test2@domain.net>,   <test3@domain.net>")}
+                };
+
+            var mailAddresses = headerDictionary.GetMailAddresses("To");
+
+            Assert.AreEqual(3, mailAddresses.Length);
+
+            var firstMailAddress = mailAddresses.ElementAt(0);
+            Assert.AreEqual("test1@domain.net", firstMailAddress.Address);
+            Assert.AreEqual("", firstMailAddress.DisplayName);
+
+            var secondMailAddress = mailAddresses.ElementAt(1);
+            Assert.AreEqual("test2@domain.net", secondMailAddress.Address);
+            Assert.AreEqual("", secondMailAddress.DisplayName);
+
+            var thirdMailAddress = mailAddresses.ElementAt(2);
+            Assert.AreEqual("test3@domain.net", thirdMailAddress.Address);
+            Assert.AreEqual("", thirdMailAddress.DisplayName);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Clients.cs" />
     <Compile Include="Shouldly.cs" />
+    <Compile Include="HeaderDictionary.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AE.Net.Mail.csproj">


### PR DESCRIPTION
I had a problem where the DisplayName part of an email address contained a comma. I wrote unit tests to ensure the current behavior as well failing unit tests for my scenario. Then I rewrote the GetMailAddresses part. I was wondering why you did something with the ; (semicolon) in your code? Is that part of some spec as I cannot find any examples of email addresses being seperated with semicolons?

In this commit:
Renamed GetAddresses to GetMailAddresses
Made sure that GetMailAddresses finds correct addresses when the DisplayName part contains a comma.
Removed looking for semicolon as I cannot find this in the mail spec and don't have any example mail headers containing semicolons to separate mail addresses.
