### PR TITLE
Added AttachmentType to Attachment.cs to differentiate between Attachments and Inline-Attachments

### DIFF
--- a/Attachment.cs
+++ b/Attachment.cs
@@ -24,6 +24,22 @@ namespace AE.Net.Mail {
 			}
 		}
 
+        public virtual AttachmentType AttachmentType
+        {
+            get
+            {
+                switch (ContentDisposition)
+                {
+                    case "attachment":
+                        return AttachmentType.Attachment;
+                    case "inline":
+                        return AttachmentType.Inline;
+                    default:
+                        return AttachmentType.Unknown;
+                }
+            }
+        }
+
 		public virtual void Save(string filename) {
 			using (var file = new System.IO.FileStream(filename, System.IO.FileMode.Create))
 				Save(file);
@@ -48,6 +64,12 @@ namespace AE.Net.Mail {
 			}
 			return data;
 		}
-
 	}
+
+    public enum AttachmentType
+    {
+        Unknown,
+        Attachment,
+        Inline
+    }
 }

--- a/Tests/Attachment.cs
+++ b/Tests/Attachment.cs
@@ -1,0 +1,57 @@
+﻿using AE.Net.Mail;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests
+{
+    [TestClass]
+    public class AttachmentTests
+    {
+        [TestMethod]
+        public void AttachmentType_ContentDispositionAttachment_Attachment()
+        {
+            var attachment = new Attachment { Headers = new HeaderDictionary { { "Content-Disposition", new HeaderValue("attachment") } } };
+
+            Assert.AreEqual(AttachmentType.Attachment, attachment.AttachmentType);
+        }
+
+        [TestMethod]
+        public void AttachmentType_ContentDispositionAttachmentWithFileName_Attachment()
+        {
+            var attachment = new Attachment { Headers = new HeaderDictionary { { "Content-Disposition", new HeaderValue(@"attachment; filename=""test.html""") } } };
+
+            Assert.AreEqual(AttachmentType.Attachment, attachment.AttachmentType);
+        }
+
+        [TestMethod]
+        public void AttachmentType_ContentDispositionInline_Inline()
+        {
+            var attachment = new Attachment { Headers = new HeaderDictionary { { "Content-Disposition", new HeaderValue("inline") } } };
+
+            Assert.AreEqual(AttachmentType.Inline, attachment.AttachmentType);
+        }
+
+        [TestMethod]
+        public void AttachmentType_ContentDispositionInlineWithFileName_Inline()
+        {
+            var attachment = new Attachment { Headers = new HeaderDictionary { { "Content-Disposition", new HeaderValue(@"inline; filename=""test.html""") } } };
+
+            Assert.AreEqual(AttachmentType.Inline, attachment.AttachmentType);
+        }
+
+        [TestMethod]
+        public void AttachmentType_ContentDispositionUnknown_Unknown()
+        {
+            var attachment = new Attachment { Headers = new HeaderDictionary { { "Content-Disposition", new HeaderValue("rubbish") } } };
+
+            Assert.AreEqual(AttachmentType.Unknown, attachment.AttachmentType);
+        }
+
+        [TestMethod]
+        public void AttachmentType_NoContentDisposition_Unknown()
+        {
+            var attachment = new Attachment { Headers = new HeaderDictionary() };
+
+            Assert.AreEqual(AttachmentType.Unknown, attachment.AttachmentType);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Clients.cs" />
     <Compile Include="Shouldly.cs" />
     <Compile Include="HeaderDictionary.cs" />
+    <Compile Include="Attachment.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AE.Net.Mail.csproj">


### PR DESCRIPTION
I wanted to filter out inline attachments in my application. There was no proper way of doing this yet and I have built it in. Could not find any more content-disposition types besides 'attachment' and 'inline'. If it is not find, it default to 'Unknown'.

Added AttachmentType to Attachment.cs to differentiate between Attachments and Inline-Attachments
Added UnitTests
