### PR TITLE
Update Tests.csproj

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Shouldly">
-      <HintPath>..\packages\Shouldly.1.1.1.1\lib\35\Shouldly.dll</HintPath>
+      <HintPath>.\packages\Shouldly.1.1.1.1\lib\35\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">


### PR DESCRIPTION
Fixed a broken reference to Shouldy.dll

The reference was assuming that the packages folder is in the root of the solution, when it's in the Tests folder.
