### PR TITLE
Added plain authentication

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -26,11 +26,17 @@ namespace AE.Net.Mail {
 			AuthMethod = method;
 			Login(username, password);
 		}
-
+		public ImapClient(string host, string username, string authUsername, string authPassword, AuthMethods method = AuthMethods.Plain, int port = 143, bool secure = false, bool skipSslValidation = false)
+		{
+			Connect(host, port, secure, skipSslValidation);
+			AuthMethod = method;
+			Login(username, authUsername, authPassword);
+		}
 		public enum AuthMethods {
 			Login,
 			CRAMMD5,
-			SaslOAuth
+			SaslOAuth,
+			Plain
 		}
 
 		public virtual AuthMethods AuthMethod { get; set; }
@@ -500,7 +506,7 @@ namespace AE.Net.Mail {
 			return x.ToArray();
 		}
 
-		internal override void OnLogin(string login, string password) {
+		internal override void OnLogin(string login, string password, string authUsername = "") {
 			string command = String.Empty;
 			string result = String.Empty;
 			string tag = GetTag();
@@ -525,6 +531,19 @@ namespace AE.Net.Mail {
 				case AuthMethods.Login:
 					command = tag + "LOGIN " + login.QuoteString() + " " + password.QuoteString();
 					result = SendCommandGetResponse(command);
+					break;
+
+				case AuthMethods.Plain:
+					command = tag + "AUTHENTICATE PLAIN";
+					result = SendCommandGetResponse(command);
+					// Null character
+					char nullChar = '\0';
+					// Set string for authentication
+					string authenticationString = String.Format("{0}{3}{1}{3}{2}", login, authUsername, password, nullChar);
+					// String must be converted to base64
+					byte[] toEncodeAsBytes = ASCIIEncoding.ASCII.GetBytes(authenticationString);
+					string returnValue = System.Convert.ToBase64String(toEncodeAsBytes);
+					result = SendCommandGetResponse(returnValue);
 					break;
 
 				case AuthMethods.SaslOAuth:

--- a/Pop3Client.cs
+++ b/Pop3Client.cs
@@ -9,7 +9,7 @@ namespace AE.Net.Mail {
 			Login(username, password);
 		}
 
-		internal override void OnLogin(string username, string password) {
+		internal override void OnLogin(string username, string password, string authUsername = "") {
 			SendCommandCheckOK("USER " + username);
 			SendCommandCheckOK("PASS " + password);
 		}

--- a/TextClient.cs
+++ b/TextClient.cs
@@ -28,7 +28,7 @@ namespace AE.Net.Mail {
 			Encoding = System.Text.Encoding.GetEncoding(1252);
 		}
 
-		internal abstract void OnLogin(string username, string password);
+		internal abstract void OnLogin(string username, string password, string authPassword = "");
 		internal abstract void OnLogout();
 		internal abstract void CheckResultOK(string result);
 
@@ -42,6 +42,17 @@ namespace AE.Net.Mail {
 			}
 			IsAuthenticated = false;
 			OnLogin(username, password);
+			IsAuthenticated = true;
+		}
+
+		public virtual void Login(string username, string authUsername, string authPassword)
+		{
+			if (!IsConnected)
+			{
+				throw new Exception("You must connect first!");
+			}
+			IsAuthenticated = false;
+			OnLogin(username, authPassword, authUsername);
 			IsAuthenticated = true;
 		}
 


### PR DESCRIPTION
I added the ability to use plain authentication. This allows an administrator user to log in to other user's mailboxes through IMAP. I needed this ability to move email from our Zimbra server to Office 365 for a migration we are doing.
