### PR TITLE
Include trailing non-ASCII in MUTF7.

### DIFF
--- a/Imap/ModifiedUtf7Encoding.cs
+++ b/Imap/ModifiedUtf7Encoding.cs
@@ -65,7 +65,7 @@ namespace AE.Net.Mail.Imap
                 }
             }
 
-            if (result.Length == 0 && nonAsciiBuffer.Length > 0) {
+            if (nonAsciiBuffer.Length > 0) {
                 result.Append(EncodeNonPrintableAsciiString(nonAsciiBuffer.ToString()));
             }
 


### PR DESCRIPTION
The current `ModifiedUtf7Encoding` fails to append trailing non-ASCII data: it only does so if the entire buffer is non-ASCII.

(Concrete example: the mailbox name `[Gmail]/全部郵件` is decoded as `[Gmail]/`.)
