### PR TITLE
fix headers only with exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ TestResults/*
 */bin/*
 */obj/*
 Tests/packages/*
+*.snk

--- a/AE.Net.Mail.csproj
+++ b/AE.Net.Mail.csproj
@@ -56,6 +56,12 @@
     <DebugSymbols>true</DebugSymbols>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>PublicPrivateKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -89,6 +95,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Create-Package.ps1" />
+    <None Include="PublicPrivateKey.snk" />
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>

--- a/MailMessage.cs
+++ b/MailMessage.cs
@@ -83,10 +83,13 @@ namespace AE.Net.Mail {
 			}
 		}
 
-		public virtual void Load(Stream reader, bool headersOnly = false, int maxLength = 0, char? termChar = null) {
+		public virtual void Load(Stream reader, bool headersOnly = false, int maxLength = 0, char? termChar = null)
+		{
 			_HeadersOnly = headersOnly;
 			Headers = null;
 			Body = null;
+			if (maxLength == 0)
+				return;
 
 
 			var headers = new StringBuilder();

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.7.9.1")]
 [assembly: AssemblyFileVersion("1.7.9.1")]
-[assembly: InternalsVisibleTo("Tests")]
+[assembly: InternalsVisibleTo("Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d7bcc3dc63b91121206d9e62c5fe7294da499ea3ac6019001e40563961744b917989df8fd594f3070133955ef01105031f8a0c92b5d5f0bf5abf457134becdb39b1bca32db48c849c994217bf327a2482b8ec0d3c8dbaba67734107f93203a7f5f19599e5bace8ecbd9c731c5af936427767df62727246a1dfcf635d62e9abcf")]

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -34,6 +34,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>PublicPrivateKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Shouldly">
@@ -66,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="PublicPrivateKey.snk" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />


### PR DESCRIPTION
When synching with Microsoft Exchange then there is sometimes a line within headers consisting only of a space (" "). Using trim will skip those values and leave the stream in a bad state with data remaining.

With headers only reading, the remaining data was not read from the stream, breaking following emails. Added an empty read for those cases just like with mails having a body.
