### PR TITLE
Fixed a SocketException in the Pop3Client.

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -457,7 +457,10 @@ namespace AE.Net.Mail {
 				var imapHeaders = Utilities.ParseImapHeader(response.Substring(response.IndexOf('(') + 1));
 				String body = (imapHeaders["BODY[HEADER]"] ?? imapHeaders["BODY[]"]);
 				if (body == null && !uidsonly) {
+#if DEBUG
 					System.Diagnostics.Debugger.Break();
+#endif
+
 					RaiseWarning(null, "Expected BODY[] in stream, but received \"" + response + "\"");
 					break;
 				}
@@ -470,14 +473,18 @@ namespace AE.Net.Mail {
 					response = GetResponse();
 					if (response == null)
 					{
+#if DEBUG
 						System.Diagnostics.Debugger.Break();
+#endif
 						RaiseWarning(null, "Expected \")\" in stream, but received nothing");
 						break;
 					}
 				}
 				var n = response.Trim().LastOrDefault();
 				if (n != ')') {
+#if DEBUG
 					System.Diagnostics.Debugger.Break();
+#endif
 					RaiseWarning(null, "Expected \")\" in stream, but received \"" + response + "\"");
 				}
 			}

--- a/Pop3Client.cs
+++ b/Pop3Client.cs
@@ -61,7 +61,9 @@ namespace AE.Net.Mail {
 			}
 
 			if (last != ".") {
+#if DEBUG
 				System.Diagnostics.Debugger.Break();
+#endif
 				RaiseWarning(msg, "Expected \".\" in stream, but received \"" + last + "\"");
 			}
 

--- a/Pop3Client.cs
+++ b/Pop3Client.cs
@@ -49,7 +49,16 @@ namespace AE.Net.Mail {
 			msg.Uid = uid;
 			var last = GetResponse();
 			if (string.IsNullOrEmpty(last))
-				last = GetResponse();
+			{
+				try
+				{
+					last = GetResponse();
+				}
+				catch (System.IO.IOException)
+				{
+					// There was really nothing back to read from the remote server
+				}
+			}
 
 			if (last != ".") {
 				System.Diagnostics.Debugger.Break();


### PR DESCRIPTION
Actually while reading a message, the Pop3Client.GetMessage(..) attempts
to call GetResponse() another time if first call returned an empty string.
Some messages sent with Lotus Notes on a SmarterMail server make this
second call crash inside the Utilities.Readline(...) function, the POP
server already sent everything back and there is nothing to read back
anymore.

Investigations shown that the content of the message was properly populated
inside the MailMessage "msg" return value.

The issue is fixed by protecting the second GetResponse call with a try
- catch block.