### PR TITLE
Fixes problem when moving an email between folders with gmail

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -254,7 +254,7 @@ namespace AE.Net.Mail {
 				prefix = "UID ";
 			}
 			string command = string.Concat(GetTag(), prefix, "COPY ", messageset, " " + destination.QuoteString());
-			SendCommandCheckOK(command);
+            SendCommandCheckOK(command, s => { } );
 			IdleResume();
 		}
 
@@ -826,5 +826,10 @@ namespace AE.Net.Mail {
 			response = response.Substring(response.IndexOf(" ")).Trim();
 			return response.ToUpper().StartsWith("OK");
 		}
+
+        protected override bool isUntaggedResponse(string response)
+        {
+            return response.Trim().StartsWith("* ");
+        }
 	}
 }

--- a/Pop3Client.cs
+++ b/Pop3Client.cs
@@ -82,5 +82,10 @@ namespace AE.Net.Mail {
 		public virtual void DeleteMessage(AE.Net.Mail.MailMessage msg) {
 			DeleteMessage(msg.Uid);
 		}
+
+        protected override bool isUntaggedResponse(string response)
+        {
+            return false;
+        }
 	}
 }

--- a/TextClient.cs
+++ b/TextClient.cs
@@ -33,6 +33,7 @@ namespace AE.Net.Mail {
 		internal abstract void OnLogin(string username, string password);
 		internal abstract void OnLogout();
 		internal abstract void CheckResultOK(string result);
+        protected abstract bool isUntaggedResponse(string response);
 
 		protected virtual void OnConnected(string result) {
 			CheckResultOK(result);
@@ -116,6 +117,23 @@ namespace AE.Net.Mail {
 			int max = 0;
 			return _Stream.ReadLine(ref max, Encoding, null, timeout);
 		}
+
+        protected virtual void SendCommandCheckOK(string command, Action<string> unilateralUntaggedCallback)
+        {
+            SendCommand(command);
+
+            while (true)
+            {
+                var response = GetResponse();
+                if (isUntaggedResponse(response))
+                    unilateralUntaggedCallback(response);
+                else
+                {
+                    CheckResultOK(response);
+                    return;
+                }
+            }
+        }
 
 		protected virtual void SendCommandCheckOK(string command) {
 			CheckResultOK(SendCommandGetResponse(command));


### PR DESCRIPTION
Problem was, in response to

xm010 UID COPY 488 "ABC/XYZ"

gmail returns

* 1 FETCH (UID 488 FLAGS (\Seen))

before the OK status