### PR TITLE
properly handle "*" responses from server during IMAP APPEND

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -217,6 +217,8 @@ namespace AE.Net.Mail {
 			string response = SendCommandGetResponse(command);
 			if (response.StartsWith("+")) {
 				response = SendCommandGetResponse(body.ToString());
+				while (response.StartsWith("*"))
+					response = GetResponse();
 			}
 			IdleResume();
 		}


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc1730#section-2.2.2

IMAP client incorrectly treats untagged responses (responses starting with "*") as a final response causing all future commands to fail and eventual server disconnect

