### PR TITLE
Allow raw imap append

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -217,6 +217,8 @@ namespace AE.Net.Mail {
 			string response = SendCommandGetResponse(command);
 			if (response.StartsWith("+")) {
 				response = SendCommandGetResponse(body.ToString());
+				while (response.StartsWith("*"))
+					response = GetResponse();
 			}
 			IdleResume();
 		}


### PR DESCRIPTION
This overloads the AppendMail() function to provide a way to send a message that is already in string format (for example if relaying from one email server to another) without having to parse into a MailMessage structure first.