### PR TITLE
Fixed search response parsing

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -797,7 +797,7 @@ namespace AE.Net.Mail
                 response += Environment.NewLine + temp;
             }
 
-            var m = Regex.Match(response, @"^\* SEARCH (.*)");
+            var m = Regex.Match(response, @"^\* SEARCH (.*)", RegexOptions.Multiline);
             return m.Groups[1].Value.Trim().Split(' ').Where(x => !string.IsNullOrEmpty(x)).ToArray();
         }
 


### PR DESCRIPTION
Added multiline option to the search response regex
Without it the "UID OK Success" line prevents the result line parsing returning an empty array